### PR TITLE
Fix search to find all the subtitles associated with one release

### DIFF
--- a/resources/lib/Addic7edUtilities.py
+++ b/resources/lib/Addic7edUtilities.py
@@ -71,7 +71,9 @@ SHOWS = {
     'Kitchen Nightmares US': 'Kitchen Nightmares',
     'Cosmos A Space Time Odyssey': 'Cosmos: A Space-Time Odyssey',
     'Greys Anatomy': 'Grey\'s Anatomy',
-    'Shameless US': 'Shameless (US)'
+    'Shameless US': 'Shameless (US)',
+    'Once Upon a Time (2011)': 'Once Upon a Time',
+    'Castle (2009)': 'Castle'
 }
 
 # Sometimes search fail because Addic7ed uses URLs that does not match the TheTVDB format.

--- a/service.py
+++ b/service.py
@@ -86,10 +86,10 @@ def query(searchurl, langs, file_original_path, filename_string):
 
   file_name = str(os.path.basename(file_original_path)).split("-")[-1].lower()
 
-  for subs in soup("td", {"class":"NewsTitle", "colspan" : "3"}):
+  for langs_html in soup("td", {"class" : "language"}):
 
     try:
-      langs_html = subs.findNext("td", {"class" : "language"})
+      subs = langs_html.findPrevious("td", {"class":"NewsTitle", "colspan" : "3"})
       fullLanguage = str(langs_html).split('class="language">')[1].split('<a')[0].replace("\n","")
       subteams = self_release_pattern.match(str(subs.contents[1])).groups()[0]
 


### PR DESCRIPTION
For each release, only the first subtitle was found. (See issue #6 )

Fixed this behavior by reversing the way search is done: first we search the subtitle language then with "findPrevious" the associated release is found.
